### PR TITLE
Update Cuda Baseimage to `nvidia/cuda:11.0.3-base-ubuntu20.04`

### DIFF
--- a/.github/create-docker/action.yml
+++ b/.github/create-docker/action.yml
@@ -88,6 +88,11 @@ runs:
           ${{ steps.args.outputs.build }} \
           ${{ inputs.path }}
       shell: bash
+
+    - name: docker image info
+      run: |
+        docker images ${{ inputs.imagename }}:${{ steps.tags.outputs.ver_tag }}
+      shell: bash
       
     - name: docker push
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         additionaltag: cuda
         path: docker/common-base/image
         dockerfile: docker/common-base/image/Dockerfile
-        baseimage: nvidia/cuda:11.0-base-ubuntu20.04
+        baseimage: nvidia/cuda:11.0.3-devel-ubuntu20.04
         additional_buildargs: |-
           disable_ssh=true
           disable_cron=true
@@ -90,7 +90,7 @@ jobs:
         imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
         additionaltag: ffmpeg-cuda
         tagversion: 4.2.1
-        baseimage: nvidia/cuda:11.0-devel-ubuntu20.04
+        baseimage: nvidia/cuda:11.0.3-devel-ubuntu20.04
         path: docker/builders/ffmpeg
         dockerfile: docker/builders/ffmpeg/Dockerfile
         additional_buildargs: |-
@@ -154,7 +154,7 @@ jobs:
         imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
         additionaltag: pytorch-cuda
         tagversion: 1.6.0_torchvision-0.7.0
-        baseimage: nvidia/cuda:11.0-devel-ubuntu20.04
+        baseimage: nvidia/cuda:11.0.3-devel-ubuntu20.04
         path: docker/builders/pytorch
         dockerfile: docker/builders/pytorch/Dockerfile
         additional_buildargs: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         additionaltag: cuda
         path: docker/common-base/image
         dockerfile: docker/common-base/image/Dockerfile
-        baseimage: nvidia/cuda:11.0.3-devel-ubuntu20.04
+        baseimage: nvidia/cuda:11.0.3-base-ubuntu20.04
         additional_buildargs: |-
           disable_ssh=true
           disable_cron=true
@@ -89,7 +89,7 @@ jobs:
         imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
         additionaltag: ffmpeg-cuda
         tagversion: 4.2.1
-        baseimage: nvidia/cuda:11.0.3-devel-ubuntu20.04
+        baseimage: nvidia/cuda:11.0.3-base-ubuntu20.04
         path: docker/builders/ffmpeg
         dockerfile: docker/builders/ffmpeg/Dockerfile
         additional_buildargs: |-
@@ -153,7 +153,7 @@ jobs:
         imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
         additionaltag: pytorch-cuda
         tagversion: 1.6.0_torchvision-0.7.0
-        baseimage: nvidia/cuda:11.0.3-devel-ubuntu20.04
+        baseimage: nvidia/cuda:11.0.3-base-ubuntu20.04
         path: docker/builders/pytorch
         dockerfile: docker/builders/pytorch/Dockerfile
         additional_buildargs: |-

--- a/Readme.md
+++ b/Readme.md
@@ -29,12 +29,12 @@ docker build -t moonvision/common-base:latest -f docker/common-base/image/Docker
 #### Common Base with CUDA
 
 ```
-docker build -t moonvision/common-base:cuda-latest -f docker/common-base/image/Dockerfile --build-arg baseimage=nvidia/cuda:11.0.3-devel-ubuntu20.04 docker/common-base/image
+docker build -t moonvision/common-base:cuda-latest -f docker/common-base/image/Dockerfile --build-arg baseimage=nvidia/cuda:11.0.3-base-ubuntu20.04 docker/common-base/image
 ```
 
 | Build arg | Default | Description |
 |-|-|-|
-| `baseimage` | [`nvidia/cuda:11.0.3-devel-ubuntu20.04`](https://hub.docker.com/r/nvidia/cuda) | Build images with different Cuda versions. |
+| `baseimage` | [`nvidia/cuda:11.0.3-base-ubuntu20.04`](https://hub.docker.com/r/nvidia/cuda) | Build images with different Cuda versions. |
 
 ### python-base
 
@@ -156,12 +156,12 @@ docker build -t moonvision/custom-builds:ffmpeg-latest -f docker/builders/ffmpeg
 #### FFmpeg with CUDA
 
 ```
-docker build -t moonvision/custom-builds:ffmpeg-cuda-latest -f docker/builders/ffmpeg/Dockerfile --build-arg baseimage=nvidia/cuda:11.0.3-devel-ubuntu20.04 --build-arg ffmpeg_version=4.2.1 --build-arg with_cuda=true docker/builders/ffmpeg
+docker build -t moonvision/custom-builds:ffmpeg-cuda-latest -f docker/builders/ffmpeg/Dockerfile --build-arg baseimage=nvidia/cuda:11.0.3-base-ubuntu20.04 --build-arg ffmpeg_version=4.2.1 --build-arg with_cuda=true docker/builders/ffmpeg
 ```
 
 | Build arg | Default | Description |
 |-|-|-|
-| `baseimage` | `nvidia/cuda:11.0.3-devel-ubuntu20.04` | Set the image on which FFmpeg will be built. |
+| `baseimage` | `nvidia/cuda:11.0.3-base-ubuntu20.04` | Set the image on which FFmpeg will be built. |
 | `ffmpeg_version` | `4.2.1` |  The FFmpeg release version to build. |
 | `with_cuda` | `true` | Whether to build FFmpeg with Nvidia hardware acceleration. |
 
@@ -188,7 +188,7 @@ docker build -t moonvision/custom-builds:pytorch-latest -f docker/builders/pytor
 
 | Build arg | Default | Description |
 |-|-|-|
-| `baseimage` | `nvidia/cuda:11.0.3-devel-ubuntu20.04` | Set the image on PyTorch FFmpeg will be built. |
+| `baseimage` | `nvidia/cuda:11.0.3-base-ubuntu20.04` | Set the image on PyTorch FFmpeg will be built. |
 | `cmake_from_docker` | `moonvision/custom-builds:cmake-3.15.5` | Image from which CMake will be installed. |
 | `python_from_docker` | `moonvision/python-base:cuda-latest` | Image to use conda python from for building. |
 | `pytorch_tag` | `v1.6.0` | PyTorch version (tag or commit if built, pip version if downloaded). |

--- a/Readme.md
+++ b/Readme.md
@@ -29,12 +29,12 @@ docker build -t moonvision/common-base:latest -f docker/common-base/image/Docker
 #### Common Base with CUDA
 
 ```
-docker build -t moonvision/common-base:cuda-latest -f docker/common-base/image/Dockerfile --build-arg baseimage=nvidia/cuda:11.0-base-ubuntu20.04 docker/common-base/image
+docker build -t moonvision/common-base:cuda-latest -f docker/common-base/image/Dockerfile --build-arg baseimage=nvidia/cuda:11.0.3-devel-ubuntu20.04 docker/common-base/image
 ```
 
 | Build arg | Default | Description |
 |-|-|-|
-| `baseimage` | [`nvidia/cuda:11.0-base-ubuntu20.04`](https://hub.docker.com/r/nvidia/cuda) | Build images with different Cuda versions. |
+| `baseimage` | [`nvidia/cuda:11.0.3-devel-ubuntu20.04`](https://hub.docker.com/r/nvidia/cuda) | Build images with different Cuda versions. |
 
 ### python-base
 
@@ -156,12 +156,12 @@ docker build -t moonvision/custom-builds:ffmpeg-latest -f docker/builders/ffmpeg
 #### FFmpeg with CUDA
 
 ```
-docker build -t moonvision/custom-builds:ffmpeg-cuda-latest -f docker/builders/ffmpeg/Dockerfile --build-arg baseimage=nvidia/cuda:11.0-devel-ubuntu20.04 --build-arg ffmpeg_version=4.2.1 --build-arg with_cuda=true docker/builders/ffmpeg
+docker build -t moonvision/custom-builds:ffmpeg-cuda-latest -f docker/builders/ffmpeg/Dockerfile --build-arg baseimage=nvidia/cuda:11.0.3-devel-ubuntu20.04 --build-arg ffmpeg_version=4.2.1 --build-arg with_cuda=true docker/builders/ffmpeg
 ```
 
 | Build arg | Default | Description |
 |-|-|-|
-| `baseimage` | `nvidia/cuda:11.0-devel-ubuntu20.04` | Set the image on which FFmpeg will be built. |
+| `baseimage` | `nvidia/cuda:11.0.3-devel-ubuntu20.04` | Set the image on which FFmpeg will be built. |
 | `ffmpeg_version` | `4.2.1` |  The FFmpeg release version to build. |
 | `with_cuda` | `true` | Whether to build FFmpeg with Nvidia hardware acceleration. |
 
@@ -188,7 +188,7 @@ docker build -t moonvision/custom-builds:pytorch-latest -f docker/builders/pytor
 
 | Build arg | Default | Description |
 |-|-|-|
-| `baseimage` | `nvidia/cuda:11.0-devel-ubuntu20.04` | Set the image on PyTorch FFmpeg will be built. |
+| `baseimage` | `nvidia/cuda:11.0.3-devel-ubuntu20.04` | Set the image on PyTorch FFmpeg will be built. |
 | `cmake_from_docker` | `moonvision/custom-builds:cmake-3.15.5` | Image from which CMake will be installed. |
 | `python_from_docker` | `moonvision/python-base:cuda-latest` | Image to use conda python from for building. |
 | `pytorch_tag` | `v1.6.0` | PyTorch version (tag or commit if built, pip version if downloaded). |

--- a/docker/builders/ffmpeg/build_ffmpeg.sh
+++ b/docker/builders/ffmpeg/build_ffmpeg.sh
@@ -24,7 +24,7 @@ cd /tmp/ffmpeg_sources/ffmpeg-${FFMPEG_VERSION}
 tmp=${WITH_CUDA/false/}
 ./configure \
     ${tmp/true/--enable-cuda --enable-cuvid --enable-nvenc \
-               --enable-nonfree --enable-libnpp \
+               --enable-nonfree \
                --extra-cflags=-I/usr/local/cuda/include \
                --extra-ldflags=-L/usr/local/cuda/lib64} \
     --enable-shared --disable-static \

--- a/docker/moonbox/install_pylon.sh
+++ b/docker/moonbox/install_pylon.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 echo Install Pylon
 
+conda install swig -y
+
 curl -o /tmp/pylon.deb https://www.baslerweb.com/fp-1551786503/media/downloads/software/pylon_software/pylon_5.2.0.13457-deb0_amd64.deb
 dpkg -i /tmp/pylon.deb
 rm -f /tmp/pylon.deb


### PR DESCRIPTION
The baseimage we've previously used is no longer updated https://gitlab.com/nvidia/container-images/cuda/-/issues/158#note_940326615

### Previous image sizes

| Image Name | Image Size
| - | -
| `moonvision/common-base:cuda-28abb241` | `345MB`
| `moonvision/python-base:cuda-28abb241` | `1.58GB`
| `moonvision/moonbox:cuda-28abb241` | `3.6GB`

### New image sizes

| Image Name | Image Size
| - | -
| `moonvision/dev-common-base:cuda-d9b79224` | `260MB`
| `moonvision/dev-python-base:cuda-d9b79224` |  `1.49GB`
| `moonvision/dev-moonbox:cuda-d9b79224` | `3.51GB`

### Dishtracker App tests

[here](https://app.circleci.com/pipelines/github/MoonVision/dishtracker-base/1606/workflows/48ea2b85-0b0f-461d-8c5b-a3432f008a3c)