### PR TITLE
BOX-99 Fix permissions for temporary pip requirements

### DIFF
--- a/docker/python-base/Dockerfile
+++ b/docker/python-base/Dockerfile
@@ -20,8 +20,8 @@ RUN cd /tmp \
 FROM ${baseimage}
 
 # Install python
-COPY . /bd_build
-RUN micromamba install -y -f /bd_build/environment.yml && \
+COPY --chown=1000:1000 . /home/$MAMBA_USER/bd_build
+RUN micromamba install -y -f /home/$MAMBA_USER/bd_build/environment.yml && \
     micromamba clean -yaf
 
 # Manifest mamba python for exec environments


### PR DESCRIPTION
# BOX-99 Fix permissions for temporary pip requirements

Since `micromamba=1.3` a temporary file is created next to the environment manifest. The fix is to have mambauser own the directory.