### PR TITLE
MP-1135 Add Python 3.11 version of python-base and other images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,14 @@ jobs:
         path: docker/python-base
         dockerfile: docker/python-base/Dockerfile
         baseimage: mambaorg/micromamba:1-bullseye
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}python-base
+        path: docker/python-base
+        dockerfile: docker/python-base/Dockerfile
+        baseimage: mambaorg/micromamba:1-bullseye
+        additionaltag: 3.11
+        additional_buildargs: env_file=environment_3.11.yml
   build-ffmpeg:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,24 @@ jobs:
           pytorch_tag=v1.11.0
           torchvision_tag=v0.12.0
           prebuilt=false
+  build-pytorch-311:
+    needs:
+    - docker-python-base
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
+        additionaltag: pytorch-3.11
+        tagversion: 2.0.1_torchvision-0.15.2
+        baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.11-latest
+        path: docker/builders/pytorch
+        dockerfile: docker/builders/pytorch/Dockerfile
+        additional_buildargs: |-
+          pytorch_tag=v2.0.1
+          torchvision_tag=v0.15.2
+          prebuilt=false
   build-pytorch-cuda:
     needs:
     - docker-python-base
@@ -122,6 +140,25 @@ jobs:
         additional_buildargs: |-
           pytorch_tag=v1.11.0
           torchvision_tag=v0.12.0
+          prebuilt=true
+          with_cuda=true
+  build-pytorch-cuda-311:
+    needs:
+    - docker-python-base
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
+        additionaltag: pytorch-cuda-3.11
+        tagversion: 2.0.1_torchvision-0.15.2
+        baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.11-latest
+        path: docker/builders/pytorch
+        dockerfile: docker/builders/pytorch/Dockerfile
+        additional_buildargs: |-
+          pytorch_tag=v2.0.1
+          torchvision_tag=v0.15.2
           prebuilt=true
           with_cuda=true
   docker-moonbox-mini:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,24 @@ jobs:
         additional_buildargs: |-
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
           pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-1.11.0_torchvision-0.12.0
+  docker-moonbox-mini-311:
+    needs:
+      - docker-python-base
+      - build-ffmpeg
+      - build-pytorch-311
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/create-docker
+        with:
+          imagename: moonvision/${{ env.IMAGE_PRE }}moonbox
+          additionaltag: mini-3.11
+          path: docker/moonbox
+          dockerfile: docker/moonbox/Dockerfile
+          baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.11-latest
+          additional_buildargs: |-
+            ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
+            pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-3.11-2.0.1_torchvision-0.15.2
   docker-moonbox-genicam:
     needs:
     - docker-python-base
@@ -198,6 +216,25 @@ jobs:
           with_genicam=true
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
           pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-1.11.0_torchvision-0.12.0
+  docker-moonbox-genicam-311:
+    needs:
+      - docker-python-base
+      - build-ffmpeg
+      - build-pytorch-311
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/create-docker
+        with:
+          imagename: moonvision/${{ env.IMAGE_PRE }}moonbox
+          additionaltag: genicam-3.11
+          path: docker/moonbox
+          dockerfile: docker/moonbox/Dockerfile
+          baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.11-latest
+          additional_buildargs: |-
+            with_genicam=true
+            ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
+            pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-3.11-2.0.1_torchvision-0.15.2
   docker-moonbox-cuda:
     needs:
     - docker-python-base
@@ -218,3 +255,23 @@ jobs:
           with_cuda=true
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-cuda-4.2.1
           pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-cuda-1.11.0_torchvision-0.12.0
+  docker-moonbox-cuda-311:
+    needs:
+    - docker-python-base
+    - build-ffmpeg-cuda
+    - build-pytorch-cuda-311
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}moonbox
+        additionaltag: cuda-3.11
+        path: docker/moonbox
+        dockerfile: docker/moonbox/Dockerfile
+        baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.11-latest
+        additional_buildargs: |-
+          with_genicam=false
+          with_cuda=true
+          ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-cuda-4.2.1
+          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-cuda-3.11-2.0.1_torchvision-0.15.2

--- a/docker/builders/pytorch/Dockerfile
+++ b/docker/builders/pytorch/Dockerfile
@@ -3,8 +3,9 @@ ARG baseimage='moonvision/python-base:latest'
 FROM $baseimage AS builder
 
 ARG DEBIAN_FRONTEND='noninteractive'
+ # fixme: Why should gcc be installed both here and in python-base? And the same for checkinstall.
 RUN apt-get update --yes --no-install-recommends \
- && apt-get install --yes gcc g++ checkinstall cmake
+ && apt-get install --yes gcc g++ checkinstall cmake --no-install-recommends
 
 COPY . /bd_build
 

--- a/docker/builders/pytorch/build_torchvision.sh
+++ b/docker/builders/pytorch/build_torchvision.sh
@@ -31,7 +31,8 @@ build_vision ()
 
 mkdir -p /packages
 
-
+# torchvision does not set an upper bound - but we need it for Python 3.8
+pip install "pillow<11"
 if [[ $prebuilt == true ]]; then
   if [[ $with_cuda == true ]]; then
     pip download torchvision==$torchvision_tag -d /packages --no-deps \

--- a/docker/python-base/Dockerfile
+++ b/docker/python-base/Dockerfile
@@ -22,7 +22,8 @@ FROM ${baseimage}
 
 # Install python
 COPY --chown=$MAMBA_USER:$MAMBA_USER . /home/$MAMBA_USER/bd_build
-RUN micromamba install -y -f /home/$MAMBA_USER/bd_build/environment.yml && \
+ARG env_file='environment.yml'
+RUN micromamba install -y -f /home/$MAMBA_USER/bd_build/$env_file && \
     micromamba clean -yaf
 
 # Manifest mamba python for exec environments

--- a/docker/python-base/environment_3.11.yml
+++ b/docker/python-base/environment_3.11.yml
@@ -16,13 +16,11 @@ dependencies:
   - mkl-include=2022.0
   - ninja
   - numpy=1.24.3
-  - python=3.8
+  - python=3.11
   - pyyaml=5.4.1
   - requests
   - six
   - typing_extensions
   - pip
   - pip:
-    # TODO: Try to unpin setuptools after upgrading pytorch
-    - setuptools==69.5.1
-    - opencv-contrib-python-headless==4.2.0.34
+    - opencv-contrib-python-headless==4.9.0.80


### PR DESCRIPTION
# [MP-1135](https://moonvision.atlassian.net/browse/MP-1135) Add 3.11 version of moonvision/python-base

## Description

In this PR I add new versions of images, which use Python 3.11. They use separate tags, so they shouldn't interfere with currently used images.
* `moonvision/python-base:3.11`
    * There is a new arg for using python3.11-specific environment file
    * Upgraded `python` 3.8 -> 3.11
    * Upgraded `numpy` 1.21.6 -> 1.24.3
    * Upgraded `opencv` 4.2.0.34 -> ~~4.7.0.72~~ ~~4.8.1.78~~ 4.9.0.80 (4.7 works in theory - but does not seem to have legacy trackers)
* `moonvision/custom-builds:pytorch(-cuda)-3.11-2.0.1_torchvision-0.15.2`
    * Uses the new `python-base` image
    * Added `--no-install-recommends` to `apt-get install` in pytorch's Dockerfile: without it there was an issue with `cmake`, which was trying to install newer versions of `gcc` and `g++`.
    * Upgraded `pytorch` 1.11.0 -> 2.0.1
    * Upgraded `torchvision` 0.12.0 -> 0.15.2
    * Restricted `pillow` <11 (for Python 3.8 builds)
* `moonvision/moonbox:(mini|genicam|cuda)-3.11`
    * Use the new `python-base` and `pytorch` images - but no other changes for images themselves

I have not analyzed changelogs of the updated dependencies and the impact for our code yet.
That could be done later (before or after merging this PR) by using these new images in builds for corresponding repositories.
But I wanted to be sure first, that we don't need any other changes in scope of this PR.

## How to test
All builds are successful


[MP-1135]: https://moonvision.atlassian.net/browse/MP-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ