### PR TITLE
MP-1136 Upgrade numpy

### DIFF
--- a/docker/python-base/environment.yml
+++ b/docker/python-base/environment.yml
@@ -21,6 +21,8 @@ dependencies:
   - requests
   - six
   - typing_extensions
+  # TODO: Try to unpin setuptools after upgrading pytorch
+  - setuptools=69.5.1
   - pip
   - pip:
     - opencv-contrib-python-headless==4.2.0.34

--- a/docker/python-base/environment.yml
+++ b/docker/python-base/environment.yml
@@ -21,9 +21,9 @@ dependencies:
   - requests
   - six
   - typing_extensions
-  # TODO: Try to unpin setuptools after upgrading pytorch
-  - setuptools=69.5.1
   - pip
   - pip:
+    # TODO: Try to unpin setuptools after upgrading pytorch
+    - setuptools=69.5.1
     - opencv-contrib-python-headless==4.2.0.34
     - opencv-python-headless==4.2.0.34

--- a/docker/python-base/environment.yml
+++ b/docker/python-base/environment.yml
@@ -24,6 +24,6 @@ dependencies:
   - pip
   - pip:
     # TODO: Try to unpin setuptools after upgrading pytorch
-    - setuptools=69.5.1
+    - setuptools==69.5.1
     - opencv-contrib-python-headless==4.2.0.34
     - opencv-python-headless==4.2.0.34

--- a/docker/python-base/environment.yml
+++ b/docker/python-base/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - mkl=2022.0
   - mkl-include=2022.0
   - ninja
-  - numpy=1.21.6
+  - numpy=1.24.3
   - python=3.8
   - pyyaml=5.4.1
   - requests


### PR DESCRIPTION
## Description
I want to upgrade `scipy` and `scikit-learn` in other repos, so that I could run tests for Python 3.11, and for this I want to make sure, that all environments have the same `numpy` version. So I'm copying the newer version from https://github.com/MoonVision/moonbox-docker/pull/12.

This should also eventually fix the warning about mismatching numpy versions between client, scheduler and workers.

In addition I am fixing broken `pytorch` builds: our current `pytorch` version is not compatible with the latest `setuptools`, but it does not set an upper boundary.

## How to test
Builds are successful.
