### PR TITLE
MP-1135 Add Python 3.9 version of python-base and other images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,14 @@ jobs:
         path: docker/python-base
         dockerfile: docker/python-base/Dockerfile
         baseimage: mambaorg/micromamba:1-bullseye
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}python-base
+        path: docker/python-base
+        dockerfile: docker/python-base/Dockerfile
+        baseimage: mambaorg/micromamba:1-bullseye
+        additionaltag: 3.9
+        additional_buildargs: env_file=environment_3.9.yml
   build-ffmpeg:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,24 @@ jobs:
         additional_buildargs: |-
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
           pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-1.11.0_torchvision-0.12.0
+  docker-moonbox-mini-39:
+    needs:
+      - docker-python-base
+      - build-ffmpeg
+      - build-pytorch-39
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/create-docker
+        with:
+          imagename: moonvision/${{ env.IMAGE_PRE }}moonbox
+          additionaltag: mini-3.9
+          path: docker/moonbox
+          dockerfile: docker/moonbox/Dockerfile
+          baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.9-latest
+          additional_buildargs: |-
+            ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
+            pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-3.9-1.11.0_torchvision-0.12.0
   docker-moonbox-genicam:
     needs:
     - docker-python-base
@@ -198,6 +216,25 @@ jobs:
           with_genicam=true
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
           pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-1.11.0_torchvision-0.12.0
+  docker-moonbox-genicam-39:
+    needs:
+      - docker-python-base
+      - build-ffmpeg
+      - build-pytorch-39
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/create-docker
+        with:
+          imagename: moonvision/${{ env.IMAGE_PRE }}moonbox
+          additionaltag: genicam-3.9
+          path: docker/moonbox
+          dockerfile: docker/moonbox/Dockerfile
+          baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.9-latest
+          additional_buildargs: |-
+            with_genicam=true
+            ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
+            pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-3.9-1.11.0_torchvision-0.12.0
   docker-moonbox-cuda:
     needs:
     - docker-python-base
@@ -218,3 +255,23 @@ jobs:
           with_cuda=true
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-cuda-4.2.1
           pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-cuda-1.11.0_torchvision-0.12.0
+  docker-moonbox-cuda-39:
+    needs:
+    - docker-python-base
+    - build-ffmpeg-cuda
+    - build-pytorch-cuda-39
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}moonbox
+        additionaltag: cuda-3.9
+        path: docker/moonbox
+        dockerfile: docker/moonbox/Dockerfile
+        baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.9-latest
+        additional_buildargs: |-
+          with_genicam=false
+          with_cuda=true
+          ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-cuda-4.2.1
+          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-cuda-3.9-1.11.0_torchvision-0.12.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,24 @@ jobs:
           pytorch_tag=v1.11.0
           torchvision_tag=v0.12.0
           prebuilt=false
+  build-pytorch-39:
+    needs:
+      - docker-python-base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/create-docker
+        with:
+          imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
+          additionaltag: pytorch-3.9
+          tagversion: 1.11.0_torchvision-0.12.0
+          baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.9-latest
+          path: docker/builders/pytorch
+          dockerfile: docker/builders/pytorch/Dockerfile
+          additional_buildargs: |-
+            pytorch_tag=v1.11.0
+            torchvision_tag=v0.12.0
+            prebuilt=false
   build-pytorch-cuda:
     needs:
     - docker-python-base
@@ -117,6 +135,25 @@ jobs:
         additionaltag: pytorch-cuda
         tagversion: 1.11.0_torchvision-0.12.0
         baseimage: moonvision/${{ env.IMAGE_PRE }}python-base
+        path: docker/builders/pytorch
+        dockerfile: docker/builders/pytorch/Dockerfile
+        additional_buildargs: |-
+          pytorch_tag=v1.11.0
+          torchvision_tag=v0.12.0
+          prebuilt=true
+          with_cuda=true
+  build-pytorch-cuda-39:
+    needs:
+    - docker-python-base
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/create-docker
+      with:
+        imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
+        additionaltag: pytorch-cuda-3.9
+        tagversion: 1.11.0_torchvision-0.12.0
+        baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:3.9-latest
         path: docker/builders/pytorch
         dockerfile: docker/builders/pytorch/Dockerfile
         additional_buildargs: |-

--- a/docker/builders/pytorch/Dockerfile
+++ b/docker/builders/pytorch/Dockerfile
@@ -3,8 +3,9 @@ ARG baseimage='moonvision/python-base:latest'
 FROM $baseimage AS builder
 
 ARG DEBIAN_FRONTEND='noninteractive'
+# fixme: Why should gcc be installed both here and in python-base? And the same for checkinstall.
 RUN apt-get update --yes --no-install-recommends \
- && apt-get install --yes gcc g++ checkinstall cmake
+ && apt-get install --yes gcc g++ checkinstall cmake --no-install-recommends
 
 COPY . /bd_build
 

--- a/docker/python-base/Dockerfile
+++ b/docker/python-base/Dockerfile
@@ -22,7 +22,8 @@ FROM ${baseimage}
 
 # Install python
 COPY --chown=$MAMBA_USER:$MAMBA_USER . /home/$MAMBA_USER/bd_build
-RUN micromamba install -y -f /home/$MAMBA_USER/bd_build/environment.yml && \
+ARG env_file='environment.yml'
+RUN micromamba install -y -f /home/$MAMBA_USER/bd_build/$env_file && \
     micromamba clean -yaf
 
 # Manifest mamba python for exec environments

--- a/docker/python-base/environment_3.9.yml
+++ b/docker/python-base/environment_3.9.yml
@@ -16,7 +16,7 @@ dependencies:
   - mkl-include=2023.2.0
   - ninja
   - numpy=1.24.3
-  - python=3.8
+  - python=3.9
   - pyyaml=5.4.1
   - requests
   - six
@@ -25,4 +25,4 @@ dependencies:
   - pip:
     # TODO: Try to unpin setuptools after upgrading pytorch
     - setuptools==69.5.1
-    - opencv-contrib-python-headless==4.2.0.34
+    - opencv-contrib-python-headless==4.4.0.46


### PR DESCRIPTION
# [MP-1135](https://moonvision.atlassian.net/browse/MP-1135) Add 3.11 version of moonvision/python-base

## Description

In this PR I add new versions of images, which use Python 3.9 (because there are issues with `pytorch` in later versions). They use separate tags, so they shouldn't interfere with currently used images.
* `moonvision/python-base:3.9`
    * There is a new arg for using python3.9-specific environment file
    * Upgraded `python` 3.8 -> 3.9
    * Upgraded `opencv` 4.2.0.34 -> 4.4.0.46
* `moonvision/custom-builds:pytorch(-cuda)-3.9-1.11.0_torchvision-0.12.0`
    * Uses the new `python-base` image
    * Added `--no-install-recommends` to `apt-get install` in pytorch's Dockerfile: without it there was an issue with `cmake`, which was trying to install newer versions of `gcc` and `g++`.
* `moonvision/moonbox:(mini|genicam|cuda)-3.9`
    * Use the new `python-base` and `pytorch` images - but no other changes for images themselves

I have not analyzed changelogs of the updated dependencies and the impact for our code yet.
That could be done later (before or after merging this PR) by using these new images in builds for corresponding repositories.
But I wanted to be sure first, that we don't need any other changes in scope of this PR.

## How to test
All builds are successful


[MP-1135]: https://moonvision.atlassian.net/browse/MP-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ