### PR TITLE
MP-1217 Sync dependency versions for Python 3.8 and 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,13 +97,13 @@ jobs:
       with:
         imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
         additionaltag: pytorch
-        tagversion: 1.11.0_torchvision-0.12.0
+        tagversion: 2.0.1_torchvision-0.15.2
         baseimage: moonvision/${{ env.IMAGE_PRE }}python-base
         path: docker/builders/pytorch
         dockerfile: docker/builders/pytorch/Dockerfile
         additional_buildargs: |-
-          pytorch_tag=v1.11.0
-          torchvision_tag=v0.12.0
+          pytorch_tag=v2.0.1
+          torchvision_tag=v0.15.2
           prebuilt=false
   build-pytorch-311:
     needs:
@@ -133,13 +133,13 @@ jobs:
       with:
         imagename: moonvision/${{ env.IMAGE_PRE }}custom-builds
         additionaltag: pytorch-cuda
-        tagversion: 1.11.0_torchvision-0.12.0
+        tagversion: 2.0.1_torchvision-0.15.2
         baseimage: moonvision/${{ env.IMAGE_PRE }}python-base
         path: docker/builders/pytorch
         dockerfile: docker/builders/pytorch/Dockerfile
         additional_buildargs: |-
-          pytorch_tag=v1.11.0
-          torchvision_tag=v0.12.0
+          pytorch_tag=v2.0.1
+          torchvision_tag=v0.15.2
           prebuilt=true
           with_cuda=true
   build-pytorch-cuda-311:
@@ -178,7 +178,7 @@ jobs:
         baseimage: moonvision/${{ env.IMAGE_PRE }}python-base:latest
         additional_buildargs: |-
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
-          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-1.11.0_torchvision-0.12.0
+          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-2.0.1_torchvision-0.15.2
   docker-moonbox-mini-311:
     needs:
       - docker-python-base
@@ -215,7 +215,7 @@ jobs:
         additional_buildargs: |-
           with_genicam=true
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-4.2.1
-          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-1.11.0_torchvision-0.12.0
+          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-2.0.1_torchvision-0.15.2
   docker-moonbox-genicam-311:
     needs:
       - docker-python-base
@@ -254,7 +254,7 @@ jobs:
           with_genicam=false
           with_cuda=true
           ffmpeg_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:ffmpeg-cuda-4.2.1
-          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-cuda-1.11.0_torchvision-0.12.0
+          pytorch_from_docker=moonvision/${{ env.IMAGE_PRE }}custom-builds:pytorch-cuda-2.0.1_torchvision-0.15.2
   docker-moonbox-cuda-311:
     needs:
     - docker-python-base

--- a/docker/python-base/environment.yml
+++ b/docker/python-base/environment.yml
@@ -23,6 +23,4 @@ dependencies:
   - typing_extensions
   - pip
   - pip:
-    # TODO: Try to unpin setuptools after upgrading pytorch
-    - setuptools==69.5.1
-    - opencv-contrib-python-headless==4.2.0.34
+    - opencv-contrib-python-headless==4.9.0.80

--- a/docker/python-base/environment_3.11.yml
+++ b/docker/python-base/environment_3.11.yml
@@ -12,8 +12,8 @@ dependencies:
   - libblas=*=*mkl
   - cffi
   - future
-  - mkl=2022.0
-  - mkl-include=2022.0
+  - mkl=2023.2.0
+  - mkl-include=2023.2.0
   - ninja
   - numpy=1.24.3
   - python=3.11


### PR DESCRIPTION
# [MP-1217](https://moonvision.atlassian.net/browse/MP-1217) Make 3.11 the default Python version for vid-api

## Description
1. Updating pytorch/torchvision and opencv for Python 3.8 to the same versions we use for 3.11 - we fixed all the issues, so we know they work.
2. Updating `mkl` for Python 3.11 - this change has been done after making a separate 3.11 branch and was not copied properly.

## How to test
* Builds pass
* vid-vision tests: https://app.circleci.com/pipelines/github/MoonVision/vid-vision/1967/workflows/0e58b67e-1ee1-45f1-9368-fe9b6b5b0664?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary


[MP-1217]: https://moonvision.atlassian.net/browse/MP-1217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ