### PR TITLE
MP-1215 uv-related fixes for base images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
           imagename: moonvision/${{ env.IMAGE_PRE }}python-base
           path: docker/python-base
           dockerfile: docker/python-base/DockerfileUV
-          baseimage: mambaorg/micromamba:1
           additionaltag: uv
           additional_buildargs: python_version=3.8
       - uses: ./.github/create-docker
@@ -50,10 +49,8 @@ jobs:
           imagename: moonvision/${{ env.IMAGE_PRE }}python-base
           path: docker/python-base
           dockerfile: docker/python-base/DockerfileUV
-          baseimage: mambaorg/micromamba:1
           additionaltag: uv-3.11
           additional_buildargs: |-
-            env_file=environment_uv.yml
             python_version=3.11
   build-ffmpeg:
     runs-on: ubuntu-latest

--- a/docker/moonbox/install_deps_uv.sh
+++ b/docker/moonbox/install_deps_uv.sh
@@ -29,12 +29,13 @@ rm -rf /ffmpeg-packages
 echo "with_cuda: ${with_cuda}"
 
 if test "$with_cuda" = "true"; then
-    bash /bd_build/install_cuda.sh
+    echo "deb http://ftp.de.debian.org/debian bookworm main non-free" | tee /etc/apt/sources.list.d/docker.list
+    apt-get update
+    apt-get install -y --no-install-recommends libnppc11
 else
     echo 'Skip Cuda'
 fi
 
-micromamba clean -yaf
 rm -rf /var/lib/apt/lists/*
 
 ldconfig

--- a/docker/python-base/DockerfileUV
+++ b/docker/python-base/DockerfileUV
@@ -14,7 +14,6 @@ CMD ["/bin/bash"]
 # Build runit-docker
 FROM preparation_stage AS build_runit_docker
 
-USER root
 
 RUN apt-get update \
  && apt-get install -y curl make gcc libc-dev checkinstall --no-install-recommends \

--- a/docker/python-base/DockerfileUV
+++ b/docker/python-base/DockerfileUV
@@ -14,7 +14,6 @@ CMD ["/bin/bash"]
 # Build runit-docker
 FROM preparation_stage AS build_runit_docker
 
-
 RUN apt-get update \
  && apt-get install -y curl make gcc libc-dev checkinstall --no-install-recommends \
  && apt-get clean
@@ -28,8 +27,6 @@ RUN cd /tmp \
  && mv *.deb /packages
 
 FROM preparation_stage
-
-USER root
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/python-base/DockerfileUV
+++ b/docker/python-base/DockerfileUV
@@ -1,5 +1,6 @@
+ARG python_version
 # This stage is copied from mambaorg/micromamba Dockerfile and contains everything except the actual micromamba stuff
-FROM debian:12-slim AS preparation_stage
+FROM python:${python_version}-slim-bookworm AS preparation_stage
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -47,14 +48,14 @@ RUN apt-get update -y \
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH"
+# We use python base image so that we didn't have to run `uv run python` all the time
+# This version should be preferred
+ENV UV_PYTHON_PREFERENCE=system
 # Without this you will have to pass `--no-sync` for each `uv run` call, because it will try to install dev requirements otherwise
 ENV UV_NO_SYNC=true
 # Next two are needed, because otherwise uv cannot find certificates
 ENV UV_NATIVE_TLS=true
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-# Install python
-ARG python_version
-RUN uv python install --no-cache $python_version
 
 # Install runit-docker
 COPY --from=build_runit_docker /packages /packages

--- a/docker/python-base/DockerfileUV
+++ b/docker/python-base/DockerfileUV
@@ -32,6 +32,8 @@ FROM preparation_stage
 
 USER root
 
+SHELL ["/bin/bash", "-c"]
+
 # Install other tools
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \

--- a/docker/python-base/DockerfileUV
+++ b/docker/python-base/DockerfileUV
@@ -1,7 +1,17 @@
-ARG baseimage='mambaorg/micromamba:1.0.0'
+# This stage is copied from mambaorg/micromamba Dockerfile and contains everything except the actual micromamba stuff
+FROM debian:12-slim AS preparation_stage
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG CERT_SOURCE='/etc/ssl/certs/ca-certificates.crt'
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV ENV_NAME="base"
+
+# Default command for "docker run"
+CMD ["/bin/bash"]
 
 # Build runit-docker
-FROM ${baseimage} AS build_runit_docker
+FROM preparation_stage AS build_runit_docker
 
 USER root
 
@@ -17,23 +27,9 @@ RUN cd /tmp \
  && mkdir /packages \
  && mv *.deb /packages
 
-FROM ${baseimage}
-
-# Install python
-COPY --chown=$MAMBA_USER:$MAMBA_USER . /home/$MAMBA_USER/bd_build
-RUN micromamba install -y -f /home/$MAMBA_USER/bd_build/environment_uv.yml && \
-    micromamba clean -yaf
-
-# Manifest mamba python for exec environments
-ENV CPATH "$MAMBA_ROOT_PREFIX/include"
-ENV PATH "$MAMBA_ROOT_PREFIX/bin:$PATH"
+FROM preparation_stage
 
 USER root
-# You may seal production images by running:
-#USER $MAMBA_USER
-
-# adduser template of $MAMBA_USER
-RUN echo "SKEL=/home/$MAMBA_USER" >> /etc/default/useradd
 
 # Install other tools
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description
There are some additional fixes for base images, which were not implemented before, because the corresponding issues were found only during the review of changes for child images:
* `environment.yml` for uv Dockerfile has been entirely removed. Actually, this Dockerfile does not even use micromamba base image anymore, just a simple debian. 
* Since we are free from micromamba, we can use python base image instead, which gives us globally available `python`
* We cannot install `libnpp` via conda now for `moonbox` images, so I'm doing this via apt. No idea, if that's an equivalent solution or not - but I don't know, what exactly to test.

## How to test
* `docker pull moonvision/dev-python-base:uv-3.11-latest`
* `docker run -it --rm moonvision/dev-python-base:uv-3.11-latest python`
* `docker run -it --rm moonvision/dev-python-base:uv-3.11-latest uv run python`

Both `run` commands should launch python
